### PR TITLE
Remove jruby-19mode from CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 rvm:
   - 2.1
   - 2.2
-  - jruby-19mode
   - jruby
   - rbx-2
 
@@ -16,5 +15,4 @@ gemfile:
 matrix:
   allow_failures:
     - rvm: jruby
-    - rvm: jruby-19mode
     - rvm: rbx-2


### PR DESCRIPTION
Since https://github.com/state-machines/state_machines/commit/38ff6188ee373a8812ba328eb4e54c894e96409d JRuby in 1.9 mode can't be used.