### PR TITLE
Fix test_should_have_defaults

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -20,7 +20,7 @@ class IntegrationTest < BaseTestCase
   end
 
   def test_should_have_defaults
-    assert_equal({:action => :save}, StateMachines::Integrations::ActiveRecord.defaults)
+    assert_equal({:action => :save, :use_transactions => true}, StateMachines::Integrations::ActiveRecord.defaults)
   end
 
   def test_should_have_a_locale_path


### PR DESCRIPTION
I'm trying to fix the 3 failing tests so we can upgrade to `state_machines` `0.3.0`. I/m starting with the easy one I'll do my best for the 2 others.

@seuros for review please.