### PR TITLE
Fix test_should_not_run_before_transitions_within_transaction

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -418,7 +418,7 @@ module StateMachines
       include ActiveModel
 
       # The default options to use for state machines using this integration
-      @defaults = {:action => :save, use_transactions: true}
+      @defaults = {:action => :save, :use_transactions => true}
       class << self
         # Classes that inherit from ActiveRecord::Base will automatically use
         # the ActiveRecord integration.

--- a/test/machine_with_event_attributes_on_validation_test.rb
+++ b/test/machine_with_event_attributes_on_validation_test.rb
@@ -3,7 +3,7 @@ require_relative 'test_helper'
 class MachineWithEventAttributesOnValidationTest < BaseTestCase
   def setup
     @model = new_model
-    @machine = StateMachines::Machine.new(@model)
+    @machine = StateMachines::Machine.new(@model, :use_transactions => false)
     @machine.event :ignite do
       transition :parked => :idling
     end


### PR DESCRIPTION
So I know this fix looks weird, but I checked out the original `pluginaweek/state_machine` gem and ran this test suite with a debugger. And it turns out that in this suite transactions were disabled.

I'm not quite sure if it was a mistake or or purpose though...


@seuros for review please.

cc @mcgain