### PR TITLE
Move declaration of ActiveRecord deps higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 
 # StateMachines Active Record Integration
 
-The Active Record integration adds support for database transactions, automatically
+The Active Record 4.1+ integration adds support for database transactions, automatically
 saving the record, named scopes, validation errors.
+
+## Dependencies
+
+Active Record 4.1+
 
 ## Installation
 
@@ -59,11 +63,6 @@ Usage of the generated scopes (assuming default column `state`):
 Vehicle.with_state(:parked)                         # also plural #with_states
 Vehicle.without_states(:first_gear, :second_gear)   # also singular #without_state
 ```
-
-
-Dependencies
-
-Active Record 4.1+
 
 ## Contributing
 


### PR DESCRIPTION
Avoids people spending hours trying to use a gem they can't use because of incompatibility.

Speaking for a friend.