### PR TITLE
Use public API to get AR casted default value.

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -439,11 +439,15 @@ module StateMachines
       end
 
       # Gets the db default for the machine's attribute
-      def owner_class_attribute_default
-        if owner_class.connected? && owner_class.table_exists?
-          if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0')
+      if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0')
+        def owner_class_attribute_default
+          if owner_class.connected? && owner_class.table_exists?
             owner_class.column_defaults[attribute.to_s]
-          else
+          end
+        end
+      else
+        def owner_class_attribute_default
+          if owner_class.connected? && owner_class.table_exists?
             if column = owner_class.columns_hash[attribute.to_s]
               column.default
             end

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -441,9 +441,7 @@ module StateMachines
       # Gets the db default for the machine's attribute
       def owner_class_attribute_default
         if owner_class.connected? && owner_class.table_exists?
-          if column = owner_class.columns_hash[attribute.to_s]
-            column.default
-          end
+          owner_class.column_defaults[attribute.to_s]
         end
       end
 

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -441,7 +441,13 @@ module StateMachines
       # Gets the db default for the machine's attribute
       def owner_class_attribute_default
         if owner_class.connected? && owner_class.table_exists?
-          owner_class.column_defaults[attribute.to_s]
+          if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0')
+            owner_class.column_defaults[attribute.to_s]
+          else
+            if column = owner_class.columns_hash[attribute.to_s]
+              column.default
+            end
+          end
         end
       end
 

--- a/test/machine_with_same_integer_column_default_test.rb
+++ b/test/machine_with_same_integer_column_default_test.rb
@@ -1,0 +1,30 @@
+require_relative 'test_helper'
+require 'stringio'
+
+class MachineWithSameIntegerColumnDefaultTest < BaseTestCase
+  def setup
+    @original_stderr, $stderr = $stderr, StringIO.new
+
+    @model = new_model do
+      connection.add_column table_name, :status, :integer, :default => 1
+    end
+    @machine = StateMachines::Machine.new(@model, :status, :initial => :parked) do
+      state :parked, :value => 1
+    end
+    @record = @model.new
+  end
+
+  def test_should_use_machine_default
+    assert_equal 1, @record.status
+  end
+
+  def test_should_not_generate_a_warning
+    assert_no_match(/have defined a different default/, $stderr.string)
+  end
+
+  def teardown
+    $stderr = @original_stderr
+    super
+  end
+end
+


### PR DESCRIPTION
`columns_hash[attribute].default` returns uncasted value and is considered private API.

Attached test will fail when default value is set to 1 on integer column in database and state with same value is used as initial.
With my change public API is used to determine default DB value (more info in https://github.com/rails/rails/commit/4d3e88fc757a1b6f6c468418af01dca677e41edf).
This fixes our problem and also satisfies attached spec.

*Thanks for this awesome gem and support.*