### PR TITLE
Match function signature with activerecord to avoid crash

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -458,7 +458,8 @@ module StateMachines
       def define_state_initializer
         if ::ActiveRecord.gem_version >= Gem::Version.new('5.0.0.alpha')
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-            def initialize(attributes = nil)
+            def initialize(*args, &block)
+              attributes = args.first
               super(attributes) do |*args|
                 self.class.state_machines.initialize_states(self, {}, attributes || {})
                 yield(*args) if block_given?


### PR DESCRIPTION
With using protected_attributes_continued, I was getting a crash in creating model. Changing the method signature to match that of activerecord methods from where this function is called fixes the problem.