### PR TITLE
By default have SMAR use nested transactions

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -418,7 +418,7 @@ module StateMachines
       include ActiveModel
 
       # The default options to use for state machines using this integration
-      @defaults = {:action => :save, use_transactions: true}
+      @defaults = {:action => :save, use_transactions: true, nested_transactions: true}
       class << self
         # Classes that inherit from ActiveRecord::Base will automatically use
         # the ActiveRecord integration.


### PR DESCRIPTION
Okay, so this is a first pass at a PR where we invite the developer to opt-in OR opt-out of nested transactions. I started small to see how the maintainers would react to this.