### PR TITLE
Fix StateMachine initial state with AR#create_with:

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -470,8 +470,10 @@ module StateMachines
         elsif ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
             def initialize(attributes = nil, options = {})
+              scoped_attributes = (attributes || {}).merge(self.class.scope_attributes)
+
               super(attributes, options) do |*args|
-                self.class.state_machines.initialize_states(self, {}, attributes || {})
+                self.class.state_machines.initialize_states(self, {}, scoped_attributes)
                 yield(*args) if block_given?
               end
             end
@@ -494,8 +496,10 @@ module StateMachines
           # Initializes dynamic states
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
             def initialize(attributes = nil, options = {})
+              scoped_attributes = (attributes || {}).merge(self.class.scope_attributes)
+
               super(attributes, options) do |*args|
-                self.class.state_machines.initialize_states(self, {}, attributes || {})
+                self.class.state_machines.initialize_states(self, {}, scoped_attributes)
                 yield(*args) if block_given?
               end
             end

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -460,7 +460,9 @@ module StateMachines
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
             def initialize(attributes = nil)
               super(attributes) do |*args|
-                self.class.state_machines.initialize_states(self, {}, attributes || {})
+                scoped_attributes = (attributes || {}).merge(self.class.scope_attributes)
+
+                self.class.state_machines.initialize_states(self, {}, scoped_attributes)
                 yield(*args) if block_given?
               end
             end

--- a/test/machine_with_initialized_state_test.rb
+++ b/test/machine_with_initialized_state_test.rb
@@ -27,6 +27,12 @@ class MachineWithInitializedStateTest < BaseTestCase
     assert_equal 'idling', record.state
   end
 
+  def test_should_allow_different_initial_state_when_using_create_with
+    record = @model.create_with(state: 'idling').new
+
+    assert_equal 'idling', record.state
+  end
+
   def test_should_allow_different_initial_state_when_dynamic
     @machine.initial_state = lambda { :parked }
     record = @model.new(:state => 'idling')


### PR DESCRIPTION
- In rails/rails@366e7e3 a change was
  made in order to fix an issue where `Record.create_with` could end
  up creating multiple nested records.
  That change had a side effect on the implementation of the
  activerecord state machine library.

  The TL;DR is that an attribute backed by state machine can't be
  initialized with the value you want and will always be the value of
  the initial state. You can find a reproduction test case here
  https://gist.github.com/Edouard-chin/6abff4cd230006a2c22cb341c198e34e

  The main difference before the rails change mentioned above, is that
  all values passed to `create_with` were merged with the attributes.
  I.e, assuming that `state` attribute is backed by a state machine,
  calling this:

  `User.create_with(state: 'created').find_or_create_by(age: '29')`

  would result in a hash like `{ state: 'created', age: '29' }`. This
  hash was then passed to the `User` constructor which is overrided
  [here](https://github.com/state-machines/state_machines-activerecord/blob/fed06d9fa64af1cba49d241f4a3ae79626946fe3/lib/state_machines/integrations/active_record.rb#L463)
  State Machine Gem was then checking the hash and would not override
  the `state` attribute if it was already present.

  Now, with the Rails change, the attributes hash looks like this
  `{ age: '29' }`. The state disappeared, it get set in another way
  thanks to `create_with_value`
  https://github.com/rails/rails/blob/517a54501d2de1225327296adde8efb91774b237/activerecord/lib/active_record/scoping.rb#L36
  Because the statemachine library doesn't receive a hash with the
  `state` key it thinks that the state wasn't set and thus assign a
  default value.

  The fix on this PR is to pass the attributes as well as the
  scoped_attributes when initializing the state machine.

cc/ @rafaelfranca 