### PR TITLE
Remove upperbound constraint on ActiveRecord

### DIFF
--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'state_machines-activemodel', '>= 0.5.0'
-  spec.add_dependency 'activerecord' , '>= 4.1', '< 6.0'
+  spec.add_dependency 'activerecord' , '>= 4.1'
   spec.add_development_dependency 'rake', '~> 10.3'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'appraisal', '>= 1'


### PR DESCRIPTION
Instead of updating the gemspec with every release we can be less
conservative. We are already testing against ActiveRecord edge.