### PR TITLE
Highlight state validations examples on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ caveat here is that, due to a constraint in ActiveRecord's validation
 framework, custom validators will not work as expected when defined to run
 in multiple states. For example:
 
-~~~
+```ruby
 class Vehicle < ActiveRecord::Base
   state_machine do
     state :first_gear, :second_gear do
@@ -80,21 +80,21 @@ class Vehicle < ActiveRecord::Base
     end
   end
 end
-~~~
+```
 
 In this case, the <tt>:speed_is_legal</tt> validation will only get run
 for the <tt>:second_gear</tt> state.  To avoid this, you can define your
 custom validation like so:
 
-~~~
-  class Vehicle < ActiveRecord::Base
-    state_machine do
-      state :first_gear, :second_gear do
-        validate {|vehicle| vehicle.speed_is_legal}
-      end
+```ruby
+class Vehicle < ActiveRecord::Base
+  state_machine do
+    state :first_gear, :second_gear do
+      validate {|vehicle| vehicle.speed_is_legal}
     end
   end
-~~~
+end
+```
 
 ## Contributing
 


### PR DESCRIPTION
Examples under `State driven validations` section were plain grey text. Added a bit of color to it. 💅 