### PR TITLE
Test against Ruby 2.7 and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2.9
   - 2.3.8
   - 2.4.6
   - 2.5.5
@@ -18,8 +17,6 @@ gemfile:
 matrix:
   include:
     - gemfile: gemfiles/active_record_5.0.gemfile
-      rvm: 2.2.9
-    - gemfile: gemfiles/active_record_5.0.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_record_5.0.gemfile
       rvm: 2.4.6
@@ -28,8 +25,6 @@ matrix:
     - gemfile: gemfiles/active_record_5.0.gemfile
       rvm: 2.6.2
     - gemfile: gemfiles/active_record_5.1.gemfile
-      rvm: 2.2.9
-    - gemfile: gemfiles/active_record_5.1.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_record_5.1.gemfile
       rvm: 2.4.6
@@ -37,8 +32,6 @@ matrix:
       rvm: 2.5.5
     - gemfile: gemfiles/active_record_5.1.gemfile
       rvm: 2.6.2
-    - gemfile: gemfiles/active_record_5.2.gemfile
-      rvm: 2.2.9
     - gemfile: gemfiles/active_record_5.2.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_record_5.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1
   - 2.2.9
   - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.2
+  - '2.7'
   - jruby
   - rbx-2
 
@@ -51,10 +51,14 @@ matrix:
       rvm: 2.5.5
     - gemfile: gemfiles/active_record_6.0.gemfile
       rvm: 2.6.2
+    - gemfile: gemfiles/active_record_6.0.gemfile
+      rvm: '2.7'
     - gemfile: gemfiles/active_record_edge.gemfile
       rvm: 2.5.5
     - gemfile: gemfiles/active_record_edge.gemfile
       rvm: 2.6.2
+    - gemfile: gemfiles/active_record_edge.gemfile
+      rvm: '2.7'
   exclude:
     - gemfile: gemfiles/active_record_4.1.gemfile
       rvm: 2.4.6
@@ -62,6 +66,14 @@ matrix:
       rvm: 2.5.5
     - gemfile: gemfiles/active_record_4.1.gemfile
       rvm: 2.6.2
+    - gemfile: gemfiles/active_record_4.1.gemfile
+      rvm: '2.7'
+    - gemfile: gemfiles/active_record_4.2.gemfile
+      rvm: '2.7'
+    - gemfile: gemfiles/active_record_5.0.gemfile
+      rvm: '2.7'
+    - gemfile: gemfiles/active_record_5.1.gemfile
+      rvm: '2.7'
   allow_failures:
     - rvm: jruby
     - rvm: rbx-2

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -507,11 +507,11 @@ module StateMachines
       def define_action_hook
         if action_hook == :save
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
-              def save(*)
+              def save(*, **)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end
 
-              def save!(*)
+              def save!(*, **)
                 result = self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
                 result || raise(ActiveRecord::RecordInvalid.new(self))
               end

--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'state_machines-activemodel', '>= 0.5.0'
   spec.add_dependency 'activerecord' , '>= 4.1'
-  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'appraisal', '>= 1'
   spec.add_development_dependency 'minitest' , '>= 5.4.0'

--- a/test/machine_with_dirty_attribute_and_custom_attributes_during_loopback_test.rb
+++ b/test/machine_with_dirty_attribute_and_custom_attributes_during_loopback_test.rb
@@ -19,6 +19,6 @@ class MachineWithDirtyAttributeAndCustomAttributesDuringLoopbackTest < BaseTestC
   end
 
   def test_should_not_track_attribute_changes
-    assert_equal nil, @record.changes['status']
+    assert_nil @record.changes['status']
   end
 end

--- a/test/machine_with_dirty_attribute_and_state_events_test.rb
+++ b/test/machine_with_dirty_attribute_and_state_events_test.rb
@@ -15,6 +15,6 @@ class MachineWithDirtyAttributeAndStateEventsTest < BaseTestCase
   end
 
   def test_should_not_track_attribute_change
-    assert_equal nil, @record.changes['state']
+    assert_nil @record.changes['state']
   end
 end

--- a/test/machine_with_dirty_attributes_during_loopback_test.rb
+++ b/test/machine_with_dirty_attributes_during_loopback_test.rb
@@ -17,6 +17,6 @@ class MachineWithDirtyAttributesDuringLoopbackTest < BaseTestCase
   end
 
   def test_should_not_track_attribute_changes
-    assert_equal nil, @record.changes['state']
+    assert_nil @record.changes['state']
   end
 end

--- a/test/machine_with_event_attributes_on_save_test.rb
+++ b/test/machine_with_event_attributes_on_save_test.rb
@@ -212,13 +212,13 @@ class MachineWithEventAttributesOnSaveTest < BaseTestCase
   def test_should_return_nil_on_around_transition_rollback
     @machine.before_transition { @model.create! }
     @machine.around_transition { @model.create!; raise ActiveRecord::Rollback }
-    assert_equal nil, @record.save
+    assert_nil @record.save
     assert_equal 0, @model.count
   end
 
   def test_should_return_nil_on_before_transition_rollback
     @machine.before_transition { raise ActiveRecord::Rollback }
-    assert_equal nil, @record.save
+    assert_nil @record.save
     assert_equal 0, @model.count
   end
 

--- a/test/machine_with_scopes_and_owner_subclass_test.rb
+++ b/test/machine_with_scopes_and_owner_subclass_test.rb
@@ -20,7 +20,7 @@ class MachineWithScopesAndOwnerSubclassTest < BaseTestCase
   def test_should_only_include_records_without_subclass_states_in_without_scope
     parked = @subclass.create :state => 'parked'
     idling = @subclass.create :state => 'idling'
-    first_gear = @subclass.create :state => 'first_gear'
+    @subclass.create :state => 'first_gear'
 
     assert_equal [parked, idling], @subclass.without_states(:first_gear).all
   end

--- a/test/machine_with_scopes_test.rb
+++ b/test/machine_with_scopes_test.rb
@@ -43,7 +43,7 @@ class MachineWithScopesTest < BaseTestCase
 
   def test_should_only_include_records_without_state_in_singular_without_scope
     parked = @model.create :state => 'parked'
-    idling = @model.create :state => 'idling'
+    @model.create :state => 'idling'
 
     assert_equal [parked], @model.without_state(:idling).all
   end
@@ -55,13 +55,13 @@ class MachineWithScopesTest < BaseTestCase
   def test_should_only_include_records_without_states_in_plural_without_scope
     parked = @model.create :state => 'parked'
     idling = @model.create :state => 'idling'
-    first_gear = @model.create :state => 'first_gear'
+    @model.create :state => 'first_gear'
 
     assert_equal [parked, idling], @model.without_states(:first_gear).all
   end
 
   def test_should_allow_chaining_scopes
-    parked = @model.create :state => 'parked'
+    @model.create :state => 'parked'
     idling = @model.create :state => 'idling'
 
     assert_equal [idling], @model.without_state(:parked).with_state(:idling).all

--- a/test/machine_with_static_initial_state_test.rb
+++ b/test/machine_with_static_initial_state_test.rb
@@ -114,7 +114,7 @@ class MachineWithStaticInitialStateTest < BaseTestCase
     MachineWithStaticInitialStateTest.const_set('Owner', owner_model)
 
     owner = owner_model.create
-    record = @model.create(:state => 'idling', :owner_id => owner.id)
+    @model.create(:state => 'idling', :owner_id => owner.id)
     assert_equal 'idling', owner.vehicles[0].state
   end
 
@@ -131,7 +131,7 @@ class MachineWithStaticInitialStateTest < BaseTestCase
     MachineWithStaticInitialStateTest.const_set('Owner', owner_model)
 
     owner = owner_model.create
-    record = @model.create(:state => 'idling', :owner_id => owner.id)
+    @model.create(:state => 'idling', :owner_id => owner.id)
     assert_equal 'idling', owner.vehicle.state
   end
 


### PR DESCRIPTION
Prevents the following warning:

```
tmp/bundle/ruby/2.7.0/gems/state_machines-activerecord-0.6.0/lib/state_machines/integrations/active_record.rb:511: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-9817d74f3be7/activerecord/lib/active_record/suppressor.rb:43: warning: The called method `save' is defined here
```

I also fixed other warnings showing up on the test suite.