### PR TITLE
Map attribute aliases to column names when initializing

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -445,7 +445,8 @@ module StateMachines
         define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
           def initialize(attributes = nil, *)
             super(attributes) do |*args|
-              scoped_attributes = (attributes || {}).merge(self.class.scope_attributes)
+              attributes = (attributes || {}).transform_keys { |key| self.class.attribute_aliases[key.to_s] || key }
+              scoped_attributes = attributes.merge(self.class.scope_attributes)
 
               self.class.state_machines.initialize_states(self, {}, scoped_attributes)
               yield(*args) if block_given?

--- a/test/machine_with_aliased_attribute_test.rb
+++ b/test/machine_with_aliased_attribute_test.rb
@@ -19,11 +19,5 @@ class MachineWithAliasedAttributeTest < BaseTestCase
     @record.vehicle_status = 'parked'
     assert @record.status?(:parked)
   end
-
-  def test_should_initialize_with_original_attribute_names
-    record = @model.new(:vehicle_status => 'bogus')
-    refute record.status?(:parked)
-    assert record.status?(:bogus)
-  end
 end
 

--- a/test/machine_with_aliased_attribute_test.rb
+++ b/test/machine_with_aliased_attribute_test.rb
@@ -19,5 +19,11 @@ class MachineWithAliasedAttributeTest < BaseTestCase
     @record.vehicle_status = 'parked'
     assert @record.status?(:parked)
   end
+
+  def test_should_initialize_with_original_attribute_names
+    record = @model.new(:vehicle_status => 'bogus')
+    refute record.status?(:parked)
+    assert record.status?(:bogus)
+  end
 end
 

--- a/test/machine_with_initialized_aliased_attribute_test.rb
+++ b/test/machine_with_initialized_aliased_attribute_test.rb
@@ -1,0 +1,20 @@
+require_relative 'test_helper'
+
+class MachineWithInitializedAliasedAttributeTest < BaseTestCase
+  def setup
+    @model = new_model do
+      alias_attribute :custom_status, :state
+    end
+
+    @machine = StateMachines::Machine.new(@model, :initial => :parked, :attribute => :state)
+    @machine.state :started
+
+    @record = @model.new(:custom_status => :started)
+  end
+
+  def test_should_match_original_attribute_value
+    refute @record.state?(:parked)
+    assert @record.state?(:started)
+  end
+end
+


### PR DESCRIPTION
Fixes https://github.com/state-machines/state_machines-activemodel/issues/2