### PR TITLE
 #101 docs(models): examples show models inheriting ApplicationRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ class Vehicle < ApplicationRecord
     end
 
     state :first_gear, :second_gear do
-      validates_presence_of :seatbelt_on
+      validates :seatbelt_on, presence: true
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For the complete usage guide, see http://www.rubydoc.info/github/state-machines/
 ### Example
 
 ```ruby
-class Vehicle < ActiveRecord::Base
+class Vehicle < ApplicationRecord
   state_machine :initial => :parked do
     before_transition :parked => any - :parked, :do => :put_on_seatbelt
     after_transition any => :parked do |vehicle, transition|
@@ -73,7 +73,7 @@ framework, custom validators will not work as expected when defined to run
 in multiple states. For example:
 
 ```ruby
-class Vehicle < ActiveRecord::Base
+class Vehicle < ApplicationRecord
   state_machine do
     state :first_gear, :second_gear do
       validate :speed_is_legal
@@ -87,7 +87,7 @@ for the <tt>:second_gear</tt> state.  To avoid this, you can define your
 custom validation like so:
 
 ```ruby
-class Vehicle < ActiveRecord::Base
+class Vehicle < ApplicationRecord
   state_machine do
     state :first_gear, :second_gear do
       validate {|vehicle| vehicle.speed_is_legal}

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -11,7 +11,7 @@ module StateMachines
     # Below is an example of a simple state machine defined within an
     # ActiveRecord model:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine :initial => :parked do
     #       event :ignite do
     #         transition :parked => :idling
@@ -82,7 +82,7 @@ module StateMachines
     # users from tampering with events through URLs / forms, the attribute
     # should be protected like so:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     attr_protected :state_event
     #     # attr_accessible ... # Alternative technique
     #
@@ -94,7 +94,7 @@ module StateMachines
     # If you want to only have *some* events be able to fire via mass-assignment,
     # you can build two state machines (one public and one protected) like so:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     attr_protected :state_event # Prevent access to events in the first machine
     #
     #     state_machine do
@@ -115,7 +115,7 @@ module StateMachines
     #
     # For example,
     #
-    #   class Message < ActiveRecord::Base
+    #   class Message < ApplicationRecord
     #   end
     #
     #   Vehicle.state_machine do
@@ -136,7 +136,7 @@ module StateMachines
     #
     # To turn off transactions:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine :initial => :parked, :use_transactions => false do
     #       ...
     #     end
@@ -150,7 +150,7 @@ module StateMachines
     # framework, custom validators will not work as expected when defined to run
     # in multiple states.  For example:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine do
     #       ...
     #       state :first_gear, :second_gear do
@@ -163,7 +163,7 @@ module StateMachines
     # for the <tt>:second_gear</tt> state.  To avoid this, you can define your
     # custom validation like so:
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine do
     #       ...
     #       state :first_gear, :second_gear do
@@ -206,8 +206,7 @@ module StateMachines
     # These named scopes are essentially the functional equivalent of the
     # following definitions:
     #
-    #   class Vehicle < ActiveRecord::Base
-    #     named_scope :with_states, lambda {|*states| {:conditions => {:state => states}}}
+    #   class Vehicle < ApplicationRecord
     #     # with_states also aliased to with_state
     #
     #     named_scope :without_states, lambda {|*states| {:conditions => ['state NOT IN (?)', states]}}
@@ -235,7 +234,7 @@ module StateMachines
     #
     # For example,
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine :initial => :parked do
     #       before_transition any => :idling do |vehicle|
     #         vehicle.put_on_seatbelt
@@ -266,11 +265,11 @@ module StateMachines
     # ActiveRecord, a save failure will cause any records that get created in
     # your callback to roll back.  You can work around this issue like so:
     #
-    #   class TransitionLog < ActiveRecord::Base
+    #   class TransitionLog < ApplicationRecord
     #     establish_connection Rails.env.to_sym
     #   end
     #
-    #   class Vehicle < ActiveRecord::Base
+    #   class Vehicle < ApplicationRecord
     #     state_machine do
     #       after_failure do |vehicle, transition|
     #         TransitionLog.create(:vehicle => vehicle, :transition => transition)

--- a/test/machine_with_event_attributes_on_validation_test.rb
+++ b/test/machine_with_event_attributes_on_validation_test.rb
@@ -65,7 +65,7 @@ class MachineWithEventAttributesOnValidationTest < BaseTestCase
   def test_should_not_run_after_callbacks_with_failures_disabled_if_validation_fails
     @model.class_eval do
       attr_accessor :seatbelt
-      validates_presence_of :seatbelt
+      validates :seatbelt, presence: true
     end
 
     ran_callback = false
@@ -78,7 +78,7 @@ class MachineWithEventAttributesOnValidationTest < BaseTestCase
   def test_should_run_after_callbacks_if_validation_fails
     @model.class_eval do
       attr_accessor :seatbelt
-      validates_presence_of :seatbelt
+      validates :seatbelt, presence: true
     end
 
     ran_callback = false
@@ -103,7 +103,7 @@ class MachineWithEventAttributesOnValidationTest < BaseTestCase
   def test_should_not_run_around_callbacks_after_yield_with_failures_disabled_if_validation_fails
     @model.class_eval do
       attr_accessor :seatbelt
-      validates_presence_of :seatbelt
+      validates :seatbelt, presence: true
     end
 
     ran_callback = false

--- a/test/machine_with_state_driven_validations_test.rb
+++ b/test/machine_with_state_driven_validations_test.rb
@@ -8,7 +8,7 @@ class MachineWithStateDrivenValidationsTest < BaseTestCase
 
     @machine = StateMachines::Machine.new(@model)
     @machine.state :first_gear, :second_gear do
-      validates_presence_of :seatbelt
+      validates :seatbelt, presence: true
     end
     @machine.other_states :parked
   end


### PR DESCRIPTION
Since Rails 5.0 or 5.1 rails explicitly asks us to inherit from
` < ApplicationRecord` and not ` < ActiveRecord::Base`.

I Know it is kind of a nit pick. But this code style flaw in the
examples still feels kind of weird.

And the fix is not all that large, right? :wink:

PS:

And then I also spotted `validates_presence_of` which is deprecated as well since ... never mind.

Also, a simple fix. 


Filling my own issue  #101