### PR TITLE
explicitly call super() to avoid hoisting args to `save!` and `save`

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -458,11 +458,11 @@ module StateMachines
         if action_hook == :save
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
               def save(*, **)
-                self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
+                self.class.state_machine(#{name.inspect}).send(:around_save, self) { super() }
               end
 
               def save!(*, **)
-                result = self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
+                result = self.class.state_machine(#{name.inspect}).send(:around_save, self) { super() }
                 result || raise(ActiveRecord::RecordInvalid.new(self))
               end
 


### PR DESCRIPTION
fixes error in Ruby 3.x

```
ArgumentError:
       wrong number of arguments (given 1, expected 0)
```