### PR TITLE
feat: Add Rails enum integration with automatic conflict resolution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 platforms :mri do
   gem 'debug'
+  gem 'rubocop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,8 @@ gemspec
 
 platforms :mri do
   gem 'debug'
+end
+
+group :development do
   gem 'rubocop'
 end

--- a/README.md
+++ b/README.md
@@ -77,7 +77,100 @@ Vehicle.with_state(params[:state])                 # Returns all vehicles if par
 Vehicle.where(color: 'red').with_state(nil)        # Returns all red vehicles (chainable)
 ```
 
-### State driven validations
+## Rails Enum Integration
+
+When your ActiveRecord model uses Rails enums and defines a state machine on the same attribute, this gem automatically detects the conflict and provides seamless integration. This prevents method name collisions between Rails enum methods and state machine methods.
+
+### Auto-Detection and Conflict Resolution
+
+```ruby
+class Order < ApplicationRecord
+  # Rails enum definition
+  enum :status, { pending: 0, processing: 1, completed: 2, cancelled: 3 }
+  
+  # State machine on the same attribute
+  state_machine :status do
+    state :pending, :processing, :completed, :cancelled
+    
+    event :process do
+      transition pending: :processing
+    end
+    
+    event :complete do
+      transition processing: :completed
+    end
+    
+    event :cancel do
+      transition [:pending, :processing] => :cancelled
+    end
+  end
+end
+```
+
+When enum integration is detected, the gem automatically:
+- Preserves original Rails enum methods (`pending?`, `processing?`, etc.)
+- Generates prefixed state machine methods to avoid conflicts (`status_pending?`, `status_processing?`, etc.)
+- Creates prefixed scope methods (`Order.status_pending`, `Order.status_processing`, etc.)
+
+### Available Methods
+
+**Original Rails enum methods (preserved):**
+```ruby
+order = Order.create(status: :pending)
+order.pending?        # => true (Rails enum method)
+order.processing?     # => false (Rails enum method)
+order.processing!     # Sets status to :processing (Rails enum method)
+
+Order.pending         # Rails enum scope
+Order.processing      # Rails enum scope
+```
+
+**Generated state machine methods (prefixed):**
+```ruby
+# Predicate methods
+order.status_pending?     # => true (state machine method)
+order.status_processing?  # => false (state machine method)
+order.status_completed?   # => false (state machine method)
+
+# Bang methods (for conflict resolution only)
+# These are placeholders and raise runtime errors
+order.status_processing!  # => raises RuntimeError
+
+# Scope methods  
+Order.status_pending      # State machine scope
+Order.status_processing   # State machine scope
+Order.not_status_pending  # Negative state machine scope
+```
+
+### Introspection API
+
+The integration provides a comprehensive introspection API for advanced use cases:
+
+```ruby
+machine = Order.state_machine(:status)
+
+# Check if enum integration is enabled
+machine.enum_integrated?  # => true
+
+# Get the Rails enum mapping
+machine.enum_mapping     # => {"pending"=>0, "processing"=>1, "completed"=>2, "cancelled"=>3}
+
+# Get original Rails enum methods that were preserved
+machine.original_enum_methods
+# => ["pending?", "processing?", "completed?", "cancelled?", "pending!", "processing!", ...]
+
+# Get state machine methods that were generated
+machine.state_machine_methods  
+# => ["status_pending?", "status_processing?", "status_completed?", "status_cancelled?", ...]
+```
+
+
+### Requirements for Enum Integration
+
+- The state machine attribute must match an existing Rails enum attribute
+- Auto-detection is enabled by default when this condition is met
+
+## State driven validations
 
 As mentioned in `StateMachines::Machine#state`, you can define behaviors,
 like validations, that only execute for certain states. One *important*

--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ The enum integration supports several configuration options:
 
 - `prefix` (default: true) - Adds a prefix to generated methods to avoid conflicts
 - `suffix` (default: false) - Alternative naming strategy using suffixes instead of prefixes
-- `validate` (default: true) - Controls whether enum validation is integrated with state machine validations
 - `scopes` (default: true) - Controls whether state machine scopes are generated
 
 ## State driven validations

--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ machine.state_machine_methods
 - The state machine attribute must match an existing Rails enum attribute
 - Auto-detection is enabled by default when this condition is met
 
+### Configuration Options
+
+The enum integration supports several configuration options:
+
+- `prefix` (default: true) - Adds a prefix to generated methods to avoid conflicts
+- `suffix` (default: false) - Alternative naming strategy using suffixes instead of prefixes
+- `validate` (default: true) - Controls whether enum validation is integrated with state machine validations
+- `scopes` (default: true) - Controls whether state machine scopes are generated
+
 ## State driven validations
 
 As mentioned in `StateMachines::Machine#state`, you can define behaviors,

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'state_machines-activemodel'
 require 'active_record'
 require 'state_machines/integrations/active_record/version'
@@ -368,6 +370,226 @@ module StateMachines
 
       # The default options to use for state machines using this integration
       @defaults = { action: :save, use_transactions: true }
+
+      # Machine-specific methods for enum integration
+      module MachineMethods
+        # Enum integration metadata storage
+        attr_accessor :enum_integration
+
+        # Hook called after machine initialization
+        def after_initialize
+          super
+          initialize_enum_integration
+        end
+
+        # Check if enum integration should be enabled for this machine
+        def detect_enum_integration
+          return nil unless owner_class.defined_enums.key?(attribute.to_s)
+
+          # For now, auto-detect enum and enable basic integration
+          # Later we can add explicit configuration options
+          {
+            enabled: true,
+            prefix: true,
+            suffix: false,
+            validate: true,
+            scopes: true,
+            enum_values: owner_class.defined_enums[attribute.to_s] || {},
+            original_enum_methods: detect_existing_enum_methods,
+            state_machine_methods: []
+          }
+        end
+
+        # Initialize enum integration if enum is detected
+        def initialize_enum_integration
+          detected_config = detect_enum_integration
+          return unless detected_config
+
+          # Store enum integration metadata
+          self.enum_integration = detected_config
+        end
+
+        # Override state method to trigger method generation after states are defined
+        def state(*, &)
+          result = super
+
+          # Generate methods after each state addition if enum integration is enabled
+          generate_state_machine_methods if enum_integrated? && !@methods_generated
+
+          result
+        end
+
+        # Check if this machine has enum integration enabled
+        def enum_integrated?
+          enum_integration && enum_integration[:enabled]
+        end
+
+        # Get the enum mapping for this attribute
+        def enum_mapping
+          return {} unless enum_integrated?
+
+          enum_integration[:enum_values] || {}
+        end
+
+        # Get list of original enum methods that were preserved
+        def original_enum_methods
+          return [] unless enum_integrated?
+
+          enum_integration[:original_enum_methods] || []
+        end
+
+        # Get list of state machine methods that were generated
+        def state_machine_methods
+          return [] unless enum_integrated?
+
+          enum_integration[:state_machine_methods] || []
+        end
+
+        private
+
+        # Detect existing enum methods for this attribute
+        def detect_existing_enum_methods
+          return [] unless owner_class.defined_enums.key?(attribute.to_s)
+
+          enum_values = owner_class.defined_enums[attribute.to_s]
+          methods = []
+
+          enum_values.each_key do |value|
+            # Predicate methods like 'active?'
+            predicate = "#{value}?"
+            methods << predicate if owner_class.method_defined?(predicate)
+
+            # Bang methods like 'active!'
+            bang_method = "#{value}!"
+            methods << bang_method if owner_class.method_defined?(bang_method)
+
+            # Scope methods (class-level)
+            methods << value.to_s if owner_class.respond_to?(value)
+            methods << "not_#{value}" if owner_class.respond_to?("not_#{value}")
+          end
+
+          methods
+        end
+
+        # Generate method name with prefix/suffix based on configuration
+        def generate_state_method_name(state_name, method_type)
+          return state_name unless enum_integrated?
+
+          config = enum_integration
+          base_name = case method_type
+                      when :predicate
+                        "#{state_name}?"
+                      when :bang
+                        "#{state_name}!"
+                      else
+                        state_name.to_s
+                      end
+
+          # Apply prefix
+          if config[:prefix]
+            prefix = config[:prefix] == true ? "#{attribute}_" : "#{config[:prefix]}_"
+            base_name = "#{prefix}#{base_name}"
+          end
+
+          # Apply suffix
+          if config[:suffix]
+            suffix = config[:suffix] == true ? "_#{attribute}" : "_#{config[:suffix]}"
+            base_name = base_name.gsub(/(\?|!)$/, "#{suffix}\\1")
+            base_name = "#{base_name}#{suffix}" unless base_name.end_with?('?', '!')
+          end
+
+          base_name
+        end
+
+        # Generate state machine methods with conflict resolution
+        def generate_state_machine_methods
+          return unless enum_integrated?
+          return if @methods_generated
+
+          # Clear any previously tracked methods
+          enum_integration[:state_machine_methods] = []
+
+          # Get all states for this machine
+          states.each do |state|
+            state_name = state.name.to_s
+            next if state_name == 'nil' # Skip nil state
+
+            # Generate predicate method (e.g., status_pending?)
+            predicate_method = generate_state_method_name(state_name, :predicate)
+            if predicate_method != "#{state_name}?"
+              define_state_predicate_method(state_name, predicate_method)
+              track_generated_method(predicate_method)
+            end
+
+            # Generate bang method (e.g., status_pending!)
+            bang_method = generate_state_method_name(state_name, :bang)
+            if bang_method != "#{state_name}!"
+              define_state_bang_method(state_name, bang_method)
+              track_generated_method(bang_method)
+            end
+
+            # Generate scope methods (e.g., status_pending)
+            scope_method = generate_state_method_name(state_name, :scope)
+            if scope_method != state_name
+              define_state_scope_method(state_name, scope_method)
+              track_generated_method(scope_method)
+            end
+          end
+
+          @methods_generated = true
+        end
+
+        # Define a prefixed predicate method for a state
+        def define_state_predicate_method(state_name, method_name)
+          machine_attribute = attribute
+          target_state_name = state_name.to_sym
+          owner_class.define_method(method_name) do
+            machine = self.class.state_machine(machine_attribute)
+            machine.states.matches?(self, target_state_name)
+          end
+        end
+
+        # Define a prefixed bang method for a state
+        def define_state_bang_method(state_name, method_name)
+          attribute
+          state_name.to_sym
+          owner_class.define_method(method_name) do
+            # For now, raise a simple runtime error
+            # This is mainly for conflict resolution, not full functionality
+            raise "#{method_name} is not implemented - this is a conflict-resolution method"
+          end
+        end
+
+        # Define a prefixed scope method for a state
+        def define_state_scope_method(state_name, method_name)
+          machine_attribute = attribute
+          scope_lambda = lambda do |value = true|
+            machine = state_machine(machine_attribute)
+            state_value = machine.states[state_name.to_sym].value
+            if value
+              where(machine_attribute => state_value)
+            else
+              where.not(machine_attribute => state_value)
+            end
+          end
+
+          owner_class.define_singleton_method(method_name, &scope_lambda)
+          owner_class.define_singleton_method("not_#{method_name}") do
+            public_send(method_name, false)
+          end
+        end
+
+        # Track generated state machine methods for introspection
+        def track_generated_method(method_name)
+          return unless enum_integrated?
+
+          enum_integration[:state_machine_methods] << method_name
+        end
+      end
+
+      # Include MachineMethods to make enum integration methods available on machine instances
+      include MachineMethods
+
       class << self
         # Classes that inherit from ActiveRecord::Base will automatically use
         # the ActiveRecord integration.
@@ -434,7 +656,7 @@ module StateMachines
 
       # Creates a scope for finding records *with* a particular state or
       # states for the attribute
-      def create_with_scope(name)
+      def create_with_scope(_name)
         attr_name = attribute
         lambda do |klass, values|
           if values.present?
@@ -447,7 +669,7 @@ module StateMachines
 
       # Creates a scope for finding records *without* a particular state or
       # states for the attribute
-      def create_without_scope(name)
+      def create_without_scope(_name)
         attr_name = attribute
         lambda do |klass, values|
           if values.present?
@@ -458,14 +680,13 @@ module StateMachines
         end
       end
 
-
       # Runs a new database transaction, rolling back any changes by raising
       # an ActiveRecord::Rollback exception if the yielded block fails
       # (i.e. returns false).
       def transaction(object)
         result = nil
         object.class.transaction do
-          raise ::ActiveRecord::Rollback unless result = yield
+          raise ::ActiveRecord::Rollback unless (result = yield)
         end
         result
       end
@@ -475,7 +696,6 @@ module StateMachines
       end
 
       private
-
 
       # Generates the results for the given scope based on one or more states to filter by
       def run_scope(scope, machine, klass, states)

--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '>= 5.4.0'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'sqlite3', '~> 1.3'
+  spec.add_development_dependency 'sqlite3', '~> 2.1'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/test/machine_with_enum_integration_test.rb
+++ b/test/machine_with_enum_integration_test.rb
@@ -25,9 +25,9 @@ class MachineWithEnumIntegrationTest < BaseTestCase
     assert @machine.respond_to?(:enum_integrated?), 'Machine should respond to enum_integrated?'
     assert @machine.enum_integrated?
     assert_equal({ 'pending' => 0, 'processing' => 1, 'completed' => 2, 'failed' => 3 }, @machine.enum_mapping)
-    
+
     # Test that states are properly defined using shared assertions
-    assert_sm_states_list(@machine, [:pending, :processing, :completed, :failed])
+    assert_sm_states_list(@machine, %i[pending processing completed failed])
   end
 
   test 'should not auto detect when no enum exists' do
@@ -38,7 +38,7 @@ class MachineWithEnumIntegrationTest < BaseTestCase
 
     assert_not machine.enum_integrated?
     # Test that states are still properly defined even without enum integration
-    assert_sm_states_list(machine, [:pending, :processing, :completed, :failed])
+    assert_sm_states_list(machine, %i[pending processing completed failed])
   end
 
   test 'should detect existing enum methods' do
@@ -71,7 +71,6 @@ class MachineWithEnumIntegrationTest < BaseTestCase
     config = machine.enum_integration
     assert_equal true, config[:prefix]
     assert_equal false, config[:suffix]
-    assert_equal true, config[:validate]
     assert_equal true, config[:scopes]
   end
 

--- a/test/machine_with_enum_integration_test.rb
+++ b/test/machine_with_enum_integration_test.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class MachineWithEnumIntegrationTest < BaseTestCase
+  def setup
+    @original_stderr = $stderr
+    $stderr = StringIO.new
+
+    @model = new_model do
+      connection.add_column table_name, :status, :integer, default: 0
+      enum :status, { pending: 0, processing: 1, completed: 2, failed: 3 }
+    end
+  end
+
+  def teardown
+    $stderr = @original_stderr
+  end
+
+  test 'should auto detect enum integration' do
+    @machine = StateMachines::Machine.new(@model, :status)
+    @machine.state :pending, :processing, :completed, :failed
+
+    # Test enum integration detection
+    assert @machine.respond_to?(:enum_integrated?), 'Machine should respond to enum_integrated?'
+    assert @machine.enum_integrated?
+    assert_equal({ 'pending' => 0, 'processing' => 1, 'completed' => 2, 'failed' => 3 }, @machine.enum_mapping)
+    
+    # Test that states are properly defined using shared assertions
+    assert_sm_states_list(@machine, [:pending, :processing, :completed, :failed])
+  end
+
+  test 'should not auto detect when no enum exists' do
+    @model_without_enum = new_model
+    machine = @model_without_enum.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    assert_not machine.enum_integrated?
+    # Test that states are still properly defined even without enum integration
+    assert_sm_states_list(machine, [:pending, :processing, :completed, :failed])
+  end
+
+  test 'should detect existing enum methods' do
+    machine = @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    original_methods = machine.original_enum_methods
+    assert_includes original_methods, 'pending?'
+    assert_includes original_methods, 'processing?'
+    assert_includes original_methods, 'completed?'
+    assert_includes original_methods, 'failed?'
+  end
+
+  test 'should generate prefixed method names for enum integration' do
+    machine = @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    assert_equal 'status_pending?', machine.send(:generate_state_method_name, 'pending', :predicate)
+    assert_equal 'status_processing!', machine.send(:generate_state_method_name, 'processing', :bang)
+    assert_equal 'status_completed', machine.send(:generate_state_method_name, 'completed', :scope)
+  end
+
+  test 'should store default enum integration metadata' do
+    machine = @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    config = machine.enum_integration
+    assert_equal true, config[:prefix]
+    assert_equal false, config[:suffix]
+    assert_equal true, config[:validate]
+    assert_equal true, config[:scopes]
+  end
+
+  test 'should generate prefixed predicate methods' do
+    @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    record = @model.create(status: :pending)
+
+    # Test using shared state machine assertions
+    assert_sm_state(record, :pending, machine_name: :status)
+
+    # Original enum methods should still work
+    assert record.pending?
+    assert_not record.processing?
+
+    # Prefixed state machine methods should be generated
+    assert record.respond_to?(:status_pending?)
+    assert record.respond_to?(:status_processing?)
+    assert record.respond_to?(:status_completed?)
+    assert record.respond_to?(:status_failed?)
+
+    # Prefixed methods should work correctly
+    assert record.status_pending?
+    assert_not record.status_processing?
+    assert_not record.status_completed?
+    assert_not record.status_failed?
+  end
+
+  test 'should generate prefixed bang methods' do
+    @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+
+      event :process do
+        transition pending: :processing
+      end
+
+      event :complete do
+        transition processing: :completed
+      end
+
+      event :fail do
+        transition %i[pending processing] => :failed
+      end
+    end
+
+    record = @model.create(status: :pending)
+
+    # Prefixed bang methods should be available
+    assert record.respond_to?(:status_processing!)
+    assert record.respond_to?(:status_completed!)
+    assert record.respond_to?(:status_failed!)
+
+    # Bang methods should exist but raise an exception (conflict resolution, not full functionality)
+    assert_raises(RuntimeError) do
+      record.status_failed!
+    end
+  end
+
+  test 'should generate prefixed scope methods' do
+    @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    pending_record = @model.create(status: :pending)
+    processing_record = @model.create(status: :processing)
+    completed_record = @model.create(status: :completed)
+
+    # Test record states using shared assertions
+    assert_sm_state(pending_record, :pending, machine_name: :status)
+    assert_sm_state(processing_record, :processing, machine_name: :status)
+    assert_sm_state(completed_record, :completed, machine_name: :status)
+
+    # Test state persistence using shared assertions
+    assert_sm_state_persisted(pending_record, 'pending', :status)
+    assert_sm_state_persisted(processing_record, 'processing', :status)
+    assert_sm_state_persisted(completed_record, 'completed', :status)
+
+    # Prefixed scope methods should be available
+    assert @model.respond_to?(:status_pending)
+    assert @model.respond_to?(:status_processing)
+    assert @model.respond_to?(:status_completed)
+    assert @model.respond_to?(:status_failed)
+
+    # Negative scope methods should be available
+    assert @model.respond_to?(:not_status_pending)
+    assert @model.respond_to?(:not_status_processing)
+
+    # Scopes should work correctly
+    assert_equal [pending_record], @model.status_pending.to_a
+    assert_equal [processing_record], @model.status_processing.to_a
+    assert_equal [completed_record], @model.status_completed.to_a
+    assert_equal [], @model.status_failed.to_a
+
+    # Negative scopes should work
+    assert_equal [processing_record, completed_record], @model.not_status_pending.order(:id).to_a
+  end
+
+  test 'should track generated methods for introspection' do
+    machine = @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    generated_methods = machine.state_machine_methods
+
+    # Should track all generated prefixed methods
+    assert_includes generated_methods, 'status_pending?'
+    assert_includes generated_methods, 'status_processing?'
+    assert_includes generated_methods, 'status_completed?'
+    assert_includes generated_methods, 'status_failed?'
+
+    assert_includes generated_methods, 'status_pending!'
+    assert_includes generated_methods, 'status_processing!'
+    assert_includes generated_methods, 'status_completed!'
+    assert_includes generated_methods, 'status_failed!'
+
+    assert_includes generated_methods, 'status_pending'
+    assert_includes generated_methods, 'status_processing'
+    assert_includes generated_methods, 'status_completed'
+    assert_includes generated_methods, 'status_failed'
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,12 @@
 require 'debug' if RUBY_ENGINE == 'ruby'
 require 'minitest/reporters'
 Minitest::Reporters.use!(Minitest::Reporters::SpecReporter.new)
+
+# Ensure our local lib directory is loaded first
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
 require 'state_machines-activerecord'
+require 'state_machines/test_helper'
 require 'minitest/autorun'
 require 'securerandom'
 
@@ -13,6 +18,7 @@ ActiveRecord::Base.logger = Logger.new("#{File.dirname(__FILE__)}/../log/active_
 ActiveSupport.test_order = :random
 
 class BaseTestCase < ActiveSupport::TestCase
+  include StateMachines::TestHelper
   protected
 
   # Creates a new ActiveRecord model (and the associated table)
@@ -32,7 +38,7 @@ class BaseTestCase < ActiveSupport::TestCase
       class << self
         self
       end).class_eval do
-        define_method(:name) { "#{name.to_s.capitalize}" }
+        define_method(:name) { name.to_s.capitalize.to_s }
       end
     end
     model.class_eval(&) if block_given?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,7 @@ class BaseTestCase < ActiveSupport::TestCase
       class << self
         self
       end).class_eval do
-        define_method(:name) { name.to_s.capitalize.to_s }
+        define_method(:name) { name.to_s.capitalize }
       end
     end
     model.class_eval(&) if block_given?


### PR DESCRIPTION
release-as: 0.50.0

10 years later [enum support](https://github.com/state-machines/state_machines-activerecord/issues/13) get resolved. 

Archaeologists from the future will find this PR and wonder why it took so long. Spoiler alert: It was legacy support all along that kept us trapped in the past.