### PR TITLE
Update Rails testing configuration to match activemodel gem

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,10 +16,7 @@ jobs:
         gemfiles:
           - gemfiles/active_record_7.2.gemfile
           - gemfiles/active_record_8.0.gemfile
-          - gemfiles/active_record_edge.gemfile
-        exclude:
-          - ruby-version: '3.0'
-            gemfiles: gemfiles/active_record_edge.gemfile
+          - gemfiles/active_record_8.1.gemfile
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfiles }}
     steps:

--- a/Appraisals
+++ b/Appraisals
@@ -2,22 +2,21 @@
 
 appraise 'active_record_7.2' do
   gem 'state_machines', github: 'state-machines/state_machines'
-  gem 'sqlite3', platforms: %i[mri rbx]
+  gem 'sqlite3', platforms: :mri
   gem 'activerecord-jdbcsqlite3-adapter', platform: %i[jruby truffleruby]
   gem 'activerecord', '~> 7.2.0'
 end
 
 appraise 'active_record_8.0' do
   gem 'state_machines', github: 'state-machines/state_machines'
-  gem 'sqlite3', platforms: %i[mri rbx]
+  gem 'sqlite3', platforms: :mri
   gem 'activerecord-jdbcsqlite3-adapter', platform: %i[jruby truffleruby]
   gem 'activerecord', '~> 8.0.0'
 end
 
-appraise 'active_record_edge' do
+appraise 'active_record_8.1' do
   gem 'state_machines', github: 'state-machines/state_machines'
   gem 'sqlite3', platforms: :mri
   gem 'activerecord-jdbcsqlite3-adapter', platform: %i[jruby truffleruby]
-  gem 'activerecord', github: 'rails/rails'
-  gem 'activemodel', github: 'rails/rails'
+  gem 'activerecord', '~> 8.1.0.beta'
 end

--- a/gemfiles/active_record_7.2.gemfile
+++ b/gemfiles/active_record_7.2.gemfile
@@ -3,9 +3,13 @@
 source "https://rubygems.org"
 
 gem "state_machines", github: "state-machines/state_machines"
-gem "sqlite3", platforms: [:mri, :rbx]
+gem "sqlite3", platforms: :mri
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 gem "activerecord", "~> 7.2.0"
+
+group :development do
+  gem "rubocop"
+end
 
 platforms :mri do
   gem "debug"

--- a/gemfiles/active_record_8.0.gemfile
+++ b/gemfiles/active_record_8.0.gemfile
@@ -3,9 +3,13 @@
 source "https://rubygems.org"
 
 gem "state_machines", github: "state-machines/state_machines"
-gem "sqlite3", platforms: [:mri, :rbx]
+gem "sqlite3", platforms: :mri
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
 gem "activerecord", "~> 8.0.0"
+
+group :development do
+  gem "rubocop"
+end
 
 platforms :mri do
   gem "debug"

--- a/gemfiles/active_record_8.1.gemfile
+++ b/gemfiles/active_record_8.1.gemfile
@@ -5,8 +5,11 @@ source "https://rubygems.org"
 gem "state_machines", github: "state-machines/state_machines"
 gem "sqlite3", platforms: :mri
 gem "activerecord-jdbcsqlite3-adapter", platform: [:jruby, :truffleruby]
-gem "activerecord", github: "rails/rails"
-gem "activemodel", github: "rails/rails"
+gem "activerecord", "~> 8.1.0.beta"
+
+group :development do
+  gem "rubocop"
+end
 
 platforms :mri do
   gem "debug"


### PR DESCRIPTION
## Summary

- Replace Rails edge testing with Rails 8.1.0.beta to align with state_machines-activemodel
- Remove rbx platform support, test only on mri, jruby, and truffleruby platforms  
- Update GitHub Actions workflow to test against Rails 7.2, 8.0, and 8.1 gemfiles
- Remove unnecessary matrix exclusions from CI configuration
- Regenerate Appraisal gemfiles for the new Rails version configuration

## Test plan

- [x] Updated Appraisals file to test Rails 7.2, 8.0, and 8.1.0.beta
- [x] Regenerated Appraisal gemfiles successfully 
- [x] Updated GitHub Actions workflow configuration
- [ ] Verify CI passes with new configuration
- [ ] Confirm all Rails versions test successfully

This change standardizes the Rails testing approach across the state_machines ecosystem by matching the configuration used in state_machines-activemodel.