### PR TITLE
Add opt-out for integer state attribute conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ machine.state_machine_methods
 
 ## Integer-backed state attributes
 
-Integer columns are converted transparently by default: application code reads
+Integer columns are converted transparently by default, application code reads
 state names while the database stores integers.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -164,6 +164,53 @@ machine.state_machine_methods
 # => ["status_pending?", "status_processing?", "status_completed?", "status_cancelled?", ...]
 ```
 
+## Integer-backed state attributes
+
+Integer columns are converted transparently by default: application code reads
+state names while the database stores integers.
+
+```ruby
+class Order < ApplicationRecord
+  state_machine :status, initial: :pending do
+    state :pending
+    state :approved
+  end
+end
+
+order = Order.create!
+order.status = :approved
+order.status # => "approved"
+# The database stores 1.
+```
+
+Applications that need the legacy raw-integer behavior can disable this during
+boot before defining affected state machines:
+
+```ruby
+# config/initializers/state_machines.rb
+
+StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
+```
+
+With this compatibility setting disabled, integer-backed state attributes are
+left to ActiveRecord's normal integer handling and reads return raw integer
+values.
+
+```ruby
+class LegacyOrder < ApplicationRecord
+  self.table_name = "orders"
+
+  state_machine :status, initial: :pending do
+    state :pending, value: 0
+    state :approved, value: 1
+  end
+end
+
+order = LegacyOrder.create!
+order.status = :approved
+order.status # => 1
+# The database stores 1.
+```
 
 ### Requirements for Enum Integration
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ machine.state_machine_methods
 
 ## Integer-backed state attributes
 
-Integer columns are converted transparently by default, application code reads
-state names while the database stores integers.
+Integer columns whose states don't declare explicit values are converted
+transparently: application code reads state names while the database stores
+integers (mapped by definition order).
 
 ```ruby
 class Order < ApplicationRecord
@@ -183,18 +184,9 @@ order.status # => "approved"
 # The database stores 1.
 ```
 
-Applications that need the legacy raw-integer behavior can disable this during
-boot before defining affected state machines:
-
-```ruby
-# config/initializers/state_machines.rb
-
-StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
-```
-
-With this compatibility setting disabled, integer-backed state attributes are
-left to ActiveRecord's normal integer handling and reads return raw integer
-values.
+Machines where every state declares an explicit integer value keep the classic
+raw-integer behavior automatically: reads return the integer and `status_name`
+returns the state name:
 
 ```ruby
 class LegacyOrder < ApplicationRecord
@@ -203,14 +195,31 @@ class LegacyOrder < ApplicationRecord
   state_machine :status, initial: :pending do
     state :pending, value: 0
     state :approved, value: 1
+
+    event :approve do
+      transition pending: :approved
+    end
   end
 end
 
 order = LegacyOrder.create!
-order.status = :approved
-order.status # => 1
+order.approve!
+order.status      # => 1
+order.status_name # => :approved
 # The database stores 1.
 ```
+
+Applications that want no type conversion at all can disable it during boot,
+before defining affected state machines:
+
+```ruby
+# config/initializers/state_machines.rb
+
+StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
+```
+
+With this setting disabled, integer-backed state attributes are left entirely
+to ActiveRecord's normal integer handling.
 
 ### Requirements for Enum Integration
 

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -372,6 +372,7 @@ module StateMachines
 
       # The default options to use for state machines using this integration
       @defaults = { action: :save, use_transactions: true }
+      @auto_convert_integer_state_attributes = true
 
       # Machine-specific methods for enum integration
       module MachineMethods
@@ -382,7 +383,9 @@ module StateMachines
         def after_initialize
           super
           initialize_enum_integration
-          register_integer_type if integer_column? && !enum_integrated?
+          if StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes && integer_column? && !enum_integrated?
+            register_integer_type
+          end
         end
 
         # Check if enum integration should be enabled for this machine
@@ -650,6 +653,8 @@ module StateMachines
       include MachineMethods
 
       class << self
+        attr_accessor :auto_convert_integer_state_attributes
+
         # Classes that inherit from ActiveRecord::Base will automatically use
         # the ActiveRecord integration.
         def matching_ancestors

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -383,9 +383,8 @@ module StateMachines
         def after_initialize
           super
           initialize_enum_integration
-          if StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes && integer_column? && !enum_integrated?
-            register_integer_type
-          end
+
+          register_integer_type if register_integer_type?
         end
 
         # Check if enum integration should be enabled for this machine
@@ -422,6 +421,15 @@ module StateMachines
           generate_state_machine_methods if enum_integrated?
 
           result
+        end
+
+        # Returns true when this machine should use the custom integer attribute type
+        # to convert between Ruby state names and integer database values. This only
+        # applies to non-enum integer columns when automatic conversion is enabled.
+        def register_integer_type?
+          StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes &&
+            integer_column? &&
+            !enum_integrated?
         end
 
         # Check if this machine has enum integration enabled

--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -463,32 +463,45 @@ module StateMachines
         end
 
         # Machine internals (state matching, validations) call read() to get the
-        # current state value and compare it against state.value.  Only override
-        # when states have explicit integer values (e.g. state :pending, value: 0).
-        # In that case the custom type returns a state name string but machine
-        # internals need the raw integer for value-based lookup.
+        # current state value and compare it against state.value. The custom
+        # integer type already returns the canonical value when state values are
+        # uniform: raw integers when every named state has an explicit integer
+        # value (passthrough), name strings when none do (state.value is the
+        # name). Only machines mixing explicit and auto-indexed values need an
+        # override, because the type returns name strings while the explicit
+        # states match on integers; map the stored value back to the matched
+        # state's canonical state.value.
         #
-        # For auto-indexed states (no explicit value), state.value is the string
-        # name so super() returns the right thing already.
+        # @param object [ActiveRecord::Base] record being read
+        # @param attr_sym [Symbol] attribute kind (:state, :event, ...)
+        # @param ivar [Boolean] whether to read from an instance variable
+        # @return [Object] a value machine internals can match on state.value
         def read(object, attr_sym, ivar = false)
           return super unless integer_type_registered? && attr_sym == :state
-          return super unless states_with_explicit_integer_values?
+          return super unless mixed_integer_state_values?
 
           raw = object.read_attribute_before_type_cast(attribute.to_s)
           if raw.is_a?(::String) || raw.is_a?(::Symbol)
             matched = states.detect { |s| s.name && s.name.to_s == raw.to_s }
-            return matched ? matched.value : raw
+            return matched.value if matched
           end
-          raw
+
+          name = owner_class.type_for_attribute(attribute.to_s).deserialize(raw)
+          matched = states.detect { |s| s.name && s.name.to_s == name.to_s }
+          matched ? matched.value : raw
         end
 
         private
 
-        # Returns true when at least one named state has an explicit integer value.
-        # Used to decide whether read() needs to return raw integers for machine
-        # internals rather than relying on the custom type's string representation.
-        def states_with_explicit_integer_values?
-          states.any? { |s| s.name && s.value.is_a?(::Integer) }
+        # Returns true when named states mix explicit integer values with
+        # auto-indexed (name-valued) states. Uses value(false) so dynamic
+        # (Proc) state values are never evaluated for this metadata decision.
+        #
+        # @return [Boolean]
+        def mixed_integer_state_values?
+          named = states.select(&:name)
+          explicit = named.count { |s| s.value(false).is_a?(::Integer) }
+          explicit.positive? && explicit < named.size
         end
 
         # Returns true when the state machine attribute is backed by an integer column
@@ -508,7 +521,8 @@ module StateMachines
         def register_integer_type
           @raw_integer_column_default = owner_class.column_defaults[attribute.to_s]
           @integer_type_registered = true
-          owner_class.attribute(attribute.to_s, StateMachines::Type::Integer.new(states))
+          raw_type = owner_class.type_for_attribute(attribute.to_s)
+          owner_class.attribute(attribute.to_s, StateMachines::Type::Integer.new(states, raw_type: raw_type))
         end
 
         # Detect existing enum methods for this attribute

--- a/lib/state_machines/integrations/active_record/type/integer.rb
+++ b/lib/state_machines/integrations/active_record/type/integer.rb
@@ -9,52 +9,107 @@ module StateMachines
     # States without explicit integer values are mapped by their index position
     # in the states collection (0, 1, 2, …). States with an explicit integer
     # value (e.g. state :pending, value: 2) use that value directly.
+    #
+    # When *every* named state has an explicit integer value, the column already
+    # stores the canonical state values and no name<->integer conversion is
+    # needed. In that case the type delegates to the column's original integer
+    # type, preserving the classic raw-integer behavior
+    # (e.g. record.status # => 1, record.status_name # => :approved).
     class Integer < ::ActiveRecord::Type::Value
-      def initialize(states)
+      # @param states [StateMachines::StateCollection] live collection of the
+      #   machine's states; held by reference because states are defined after
+      #   the type is registered
+      # @param raw_type [ActiveModel::Type::Value, nil] the column's original
+      #   attribute type, used verbatim in passthrough mode so adapter-specific
+      #   integer behavior (limits, range checks) is preserved
+      def initialize(states, raw_type: nil)
         @states = states
+        @raw_type = raw_type || ::ActiveModel::Type::Integer.new
         super()
       end
 
-      # integer from DB → state name string
+      # Converts an integer from the database to a state name string.
+      #
+      # @param value [Integer, String, nil] raw database value
+      # @return [String, Integer, nil] state name, or the original type's value
+      #   in passthrough mode, or the raw value when no state matches
       def deserialize(value)
+        states = named_states
+        return @raw_type.deserialize(value) if passthrough?(states)
         return nil if value.nil?
+
         int_val = value.to_i
-        state = named_states.detect { |s| state_integer(s) == int_val }
+        state = states.detect { |s| state_integer(s, states) == int_val }
         state ? state.name.to_s : value
       end
 
-      # assignment (symbol / string / integer) → state name string (in-memory)
+      # Converts an assigned value (symbol, string, or integer) to the in-memory
+      # state name string.
+      #
+      # @param value [Symbol, String, Integer, nil] assigned value
+      # @return [String, Integer, nil] state name, or the original type's cast
+      #   in passthrough mode
       def cast(value)
+        states = named_states
+        return @raw_type.cast(value) if passthrough?(states)
         return nil if value.nil?
-        state = named_states.detect { |s| s.name.to_s == value.to_s }
-        state ||= named_states.detect { |s| state_integer(s) == value.to_i } if value.respond_to?(:to_i)
+
+        state = states.detect { |s| s.name.to_s == value.to_s }
+        state ||= states.detect { |s| state_integer(s, states) == value.to_i } if value.respond_to?(:to_i)
         state ? state.name.to_s : value.to_s
       end
 
-      # state name string → integer for DB write
+      # Converts a state name string to its integer for the database write.
+      #
+      # @param value [String, Symbol, Integer, nil] in-memory value
+      # @return [Integer, nil] integer to store
       def serialize(value)
+        states = named_states
+        return @raw_type.serialize(value) if passthrough?(states)
         return nil if value.nil?
-        state = named_states.detect { |s| s.name.to_s == value.to_s }
-        state ? state_integer(state) : value
+
+        state = states.detect { |s| s.name.to_s == value.to_s }
+        state ? state_integer(state, states) : value
       end
 
+      # @return [Symbol] the ActiveModel type identifier
       def type
         :integer
       end
 
       private
 
-      # All non-nil states in definition order — not memoized because states are
+      # All non-nil states in definition order, not memoized because states are
       # added to the collection after the type is instantiated.
+      #
+      # @return [Array<StateMachines::State>]
       def named_states
         @states.reject { |s| s.name.nil? }
       end
 
-      # Returns the integer to use for storage:
-      # - explicit integer value if set (e.g. state :pending, value: 2)
-      # - otherwise the index position among named states
-      def state_integer(state)
-        state.value.is_a?(::Integer) ? state.value : named_states.index(state)
+      # Whether the machine was defined for raw integer storage, in which case
+      # conversion would change documented behavior. True when every named state
+      # declares an explicit integer value. Evaluated lazily on every call
+      # because states (and their values) are defined after the type is
+      # registered. Uses value(false) so dynamic (Proc) state values are never
+      # evaluated for this metadata decision.
+      #
+      # @param states [Array<StateMachines::State>] pre-computed named states
+      # @return [Boolean]
+      def passthrough?(states)
+        states.any? && states.all? { |s| s.value(false).is_a?(::Integer) }
+      end
+
+      # The integer to use for storage: the explicit state value if set
+      # (e.g. state :pending, value: 2), otherwise the index position among
+      # named states.
+      #
+      # @param state [StateMachines::State]
+      # @param states [Array<StateMachines::State>] pre-computed named states
+      # @return [Integer]
+      def state_integer(state, states)
+        value = state.value(false)
+        value.is_a?(::Integer) ? value : states.index(state)
       end
     end
   end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -3,6 +3,11 @@
 require_relative 'test_helper'
 
 class IntegrationTest < BaseTestCase
+  def teardown
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = true
+    super
+  end
+
   def test_should_have_an_integration_name
     assert_equal :active_record, StateMachines::Integrations::ActiveRecord.integration_name
   end
@@ -23,5 +28,15 @@ class IntegrationTest < BaseTestCase
 
   def test_should_have_defaults
     assert_equal({ action: :save, use_transactions: true }, StateMachines::Integrations::ActiveRecord.defaults)
+  end
+
+  def test_should_auto_convert_integer_state_attributes_by_default
+    assert_equal true, StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes
+  end
+
+  def test_should_allow_integer_state_attribute_conversion_to_be_disabled
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
+
+    assert_equal false, StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes
   end
 end

--- a/test/machine_with_different_integer_column_default_test.rb
+++ b/test/machine_with_different_integer_column_default_test.rb
@@ -17,7 +17,7 @@ class MachineWithDifferentIntegerColumnDefaultTest < BaseTestCase
   end
 
   def test_should_use_machine_default
-    assert_equal 'parked', @record.status
+    assert_equal 1, @record.status
   end
 
   def test_should_generate_a_warning

--- a/test/machine_with_enum_integration_test.rb
+++ b/test/machine_with_enum_integration_test.rb
@@ -14,7 +14,9 @@ class MachineWithEnumIntegrationTest < BaseTestCase
   end
 
   def teardown
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = true
     $stderr = @original_stderr
+    super
   end
 
   test 'should auto detect enum integration' do
@@ -28,6 +30,18 @@ class MachineWithEnumIntegrationTest < BaseTestCase
 
     # Test that states are properly defined using shared assertions
     assert_sm_states_list(@machine, %i[pending processing completed failed])
+  end
+
+  test 'should keep enum integration when integer conversion is disabled' do
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
+
+    machine = @model.state_machine(:status) do
+      state :pending, :processing, :completed, :failed
+    end
+
+    assert machine.enum_integrated?
+    refute machine.integer_type_registered?
+    assert_equal({ 'pending' => 0, 'processing' => 1, 'completed' => 2, 'failed' => 3 }, machine.enum_mapping)
   end
 
   test 'should not auto detect when no enum exists' do

--- a/test/machine_with_explicit_integer_values_test.rb
+++ b/test/machine_with_explicit_integer_values_test.rb
@@ -2,10 +2,13 @@
 
 require_relative 'test_helper'
 
-# Regression test: states with explicit integer values must work correctly.
-# Without a fix, StateCollection#match returns nil because Machine#read returns
-# the state name string ("parked") but state.value is an integer (1), so the
-# value-based lookup never matches.
+# Regression test for https://github.com/state-machines/state_machines-activerecord/issues/132
+#
+# Machines whose named states all declare explicit integer values
+# (state :pending, value: 0) are defined for raw integer storage: reads return
+# the integer, status_name returns the state name. The custom integer type
+# must pass values through untouched for these machines instead of converting
+# them to state name strings.
 class MachineWithExplicitIntegerValuesTest < BaseTestCase
   def setup
     @model = new_model do
@@ -30,36 +33,46 @@ class MachineWithExplicitIntegerValuesTest < BaseTestCase
     @record.save!
   end
 
-  def test_should_return_state_name_on_read
-    assert_equal 'pending', @record.status
+  def test_should_read_raw_integer_value
+    assert_equal 0, @record.status
   end
 
   def test_status_name_returns_correct_symbol
     assert_equal :pending, @record.status_name
   end
 
-  def test_should_accept_symbol_on_write
-    @record.status = :declined
-    assert_equal 'declined', @record.status
+  def test_should_accept_integer_on_write
+    @record.status = 2
+
+    assert_equal 2, @record.status
+    assert_equal :declined, @record.status_name
+  end
+
+  def test_should_accept_numeric_string_on_write
+    @record.status = '1'
+
+    assert_equal 1, @record.status
+    assert_equal :approved, @record.status_name
   end
 
   def test_should_persist_explicit_integer_on_save
-    @record.status = :approved
-    @record.save!
+    @record.approve!
     raw = @model.connection.select_value("SELECT status FROM #{@model.quoted_table_name} WHERE id = #{@record.id}")
+
     assert_equal 1, raw.to_i
   end
 
-  def test_should_reload_as_state_name
-    @record.status = :declined
-    @record.save!
+  def test_should_reload_as_raw_integer
+    @record.decline!
     reloaded = @model.find(@record.id)
-    assert_equal 'declined', reloaded.status
+
+    assert_equal 2, reloaded.status
   end
 
   def test_transition_fires_correctly
     @record.approve!
-    assert_equal 'approved', @record.status
+
+    assert_equal 1, @record.status
   end
 
   def test_predicate_returns_correct_result
@@ -75,5 +88,9 @@ class MachineWithExplicitIntegerValuesTest < BaseTestCase
     assert_includes @model.with_status(:pending), @record
     assert_includes @model.with_status(:approved), approved
     refute_includes @model.with_status(:approved), @record
+  end
+
+  def test_scope_uses_raw_integer_relation_condition
+    assert_equal({ 'status' => 1 }, @model.with_status(:approved).where_values_hash)
   end
 end

--- a/test/machine_with_integer_column_conversion_disabled_test.rb
+++ b/test/machine_with_integer_column_conversion_disabled_test.rb
@@ -67,6 +67,27 @@ class MachineWithIntegerColumnConversionDisabledTest < BaseTestCase
     refute_includes @model.with_status(:approved), @record
   end
 
+  def test_scope_uses_raw_integer_relation_condition
+    assert_equal({ 'status' => 1 }, @model.with_status(:approved).where_values_hash)
+  end
+
+  def test_plural_scope_uses_raw_integer_relation_condition
+    assert_equal({ 'status' => [0, 2] }, @model.with_statuses(:pending, :declined).where_values_hash)
+  end
+
+  def test_scope_on_custom_integer_attribute_uses_raw_integer_relation_condition
+    model = new_model do
+      connection.add_column table_name, :state_cd, :integer, default: 1
+    end
+
+    model.state_machine(:state, attribute: :state_cd, initial: :enabled) do
+      state :disabled, value: 0
+      state :enabled,  value: 1
+    end
+
+    assert_equal({ 'state_cd' => 1 }, model.with_state(:enabled).where_values_hash)
+  end
+
   def test_should_persist_raw_integer_on_save
     @record.approve!
     @record.save!

--- a/test/machine_with_integer_column_conversion_disabled_test.rb
+++ b/test/machine_with_integer_column_conversion_disabled_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class MachineWithIntegerColumnConversionDisabledTest < BaseTestCase
+  def setup
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
+
+    @model = new_model do
+      connection.add_column table_name, :status, :integer, default: 0
+    end
+
+    @machine = StateMachines::Machine.new(@model, :status, initial: :pending) do
+      state :pending,  value: 0
+      state :approved, value: 1
+      state :declined, value: 2
+
+      event :approve do
+        transition pending: :approved
+      end
+
+      event :decline do
+        transition pending: :declined
+      end
+    end
+
+    @record = @model.new
+    @record.save!
+  end
+
+  def teardown
+    StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = true
+    super
+  end
+
+  def test_should_not_register_custom_integer_type
+    refute @machine.integer_type_registered?
+    assert_equal :integer, @model.type_for_attribute('status').type
+  end
+
+  def test_should_read_raw_integer_value
+    assert_equal 0, @record.status
+  end
+
+  def test_status_name_returns_symbol
+    assert_equal :pending, @record.status_name
+  end
+
+  def test_transition_fires_correctly_with_raw_integer_values
+    @record.approve!
+
+    assert_equal 1, @record.status
+  end
+
+  def test_predicate_returns_correct_result
+    assert @record.pending?
+    refute @record.approved?
+  end
+
+  def test_scope_returns_correct_records
+    approved = @model.new
+    approved.save!
+    approved.approve!
+
+    assert_includes @model.with_status(:pending), @record
+    assert_includes @model.with_status(:approved), approved
+    refute_includes @model.with_status(:approved), @record
+  end
+
+  def test_should_persist_raw_integer_on_save
+    @record.approve!
+    @record.save!
+    raw = @model.connection.select_value("SELECT status FROM #{@model.quoted_table_name} WHERE id = #{@record.id}")
+
+    assert_equal 1, raw.to_i
+  end
+end

--- a/test/machine_with_integer_column_conversion_disabled_test.rb
+++ b/test/machine_with_integer_column_conversion_disabled_test.rb
@@ -42,8 +42,19 @@ class MachineWithIntegerColumnConversionDisabledTest < BaseTestCase
     assert_equal 0, @record.status
   end
 
+  def test_machine_read_uses_raw_integer_value
+    assert_equal 0, @machine.read(@record, :state)
+  end
+
   def test_status_name_returns_symbol
     assert_equal :pending, @record.status_name
+  end
+
+  def test_should_not_convert_state_name_assignment
+    @record.status = :approved
+
+    assert_nil @record.status
+    assert_equal :approved, @record.status_before_type_cast
   end
 
   def test_transition_fires_correctly_with_raw_integer_values
@@ -73,6 +84,15 @@ class MachineWithIntegerColumnConversionDisabledTest < BaseTestCase
 
   def test_plural_scope_uses_raw_integer_relation_condition
     assert_equal({ 'status' => [0, 2] }, @model.with_statuses(:pending, :declined).where_values_hash)
+  end
+
+  def test_without_scope_excludes_records_using_raw_integer_values
+    approved = @model.new
+    approved.save!
+    approved.approve!
+
+    assert_includes @model.without_status(:approved), @record
+    refute_includes @model.without_status(:approved), approved
   end
 
   def test_scope_on_custom_integer_attribute_uses_raw_integer_relation_condition

--- a/test/machine_with_mixed_integer_values_test.rb
+++ b/test/machine_with_mixed_integer_values_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Machines mixing explicit integer values with auto-indexed states keep the
+# transparent name conversion, while machine internals match each state on its
+# canonical state.value (integer for explicit states, name string for
+# auto-indexed ones).
+class MachineWithMixedIntegerValuesTest < BaseTestCase
+  def setup
+    @model = new_model do
+      connection.add_column table_name, :status, :integer, default: 0
+    end
+
+    @machine = StateMachines::Machine.new(@model, :status, initial: :pending) do
+      state :pending            # auto-indexed => 0
+      state :approved, value: 5 # explicit
+
+      event :approve do
+        transition pending: :approved
+      end
+    end
+
+    @record = @model.new
+    @record.save!
+  end
+
+  def test_should_read_state_name
+    assert_equal 'pending', @record.status
+  end
+
+  def test_status_name_returns_correct_symbol
+    assert_equal :pending, @record.status_name
+  end
+
+  def test_predicate_returns_correct_result
+    assert @record.pending?
+    refute @record.approved?
+  end
+
+  def test_transition_fires_correctly
+    @record.approve!
+
+    assert_equal 'approved', @record.status
+    assert @record.approved?
+  end
+
+  def test_should_persist_explicit_integer_on_save
+    @record.approve!
+    raw = @model.connection.select_value("SELECT status FROM #{@model.quoted_table_name} WHERE id = #{@record.id}")
+
+    assert_equal 5, raw.to_i
+  end
+
+  def test_should_reload_as_state_name
+    @record.approve!
+    reloaded = @model.find(@record.id)
+
+    assert_equal 'approved', reloaded.status
+    assert_equal :approved, reloaded.status_name
+  end
+end

--- a/test/machine_with_same_integer_column_default_test.rb
+++ b/test/machine_with_same_integer_column_default_test.rb
@@ -18,7 +18,7 @@ class MachineWithSameIntegerColumnDefaultTest < BaseTestCase
   end
 
   def test_should_use_machine_default
-    assert_equal 'parked', @record.status
+    assert_equal 1, @record.status
   end
 
   def test_should_not_generate_a_warning


### PR DESCRIPTION
## Summary

Adds a global compatibility option to opt out of automatic integer-backed state attribute conversion.

By default, it keeps the current behavior: integer-backed state machine attributes transparently convert between state names in Ruby and integers in the database.

Applications that need the previous raw-integer behavior will be able to disable the conversion during boot:

```ruby
StateMachines::Integrations::ActiveRecord.auto_convert_integer_state_attributes = false
```

## Motivation
Recent integer column support made integer-backed state machine attributes behave more like string-backed attributes:

- `record.status` returns "pending" (for example) instead of `0`
- `record.status = :approved` persists the mapped integer

That behavior is useful and remains the default, but it can be a **breaking behavioral change** for applications that already depend on reading raw integer values from state attributes.

This PR proposes a compatibility escape hatch without rolling back the integer column support.

It supports https://github.com/state-machines/state_machines-activerecord/issues/132