### PR TITLE
feat: remove redundant run_scope override

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -759,12 +759,6 @@ module StateMachines
 
       private
 
-      # Generates the results for the given scope based on one or more states to filter by
-      def run_scope(scope, machine, klass, states)
-        values = states.flatten.compact.map { |state| machine.states.fetch(state).value }
-        scope.call(klass, values)
-      end
-
       # ActiveModel's use of method_missing / respond_to for attribute methods
       # breaks both ancestor lookups and defined?(super).  Need to special-case
       # the existence of query attribute methods.

--- a/state_machines-activerecord.gemspec
+++ b/state_machines-activerecord.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '>= 7.2'
-  spec.add_dependency 'state_machines-activemodel', '>= 0.102.0'
+  spec.add_dependency 'state_machines-activemodel', '>= 0.200.0'
   spec.add_development_dependency 'appraisal', '>= 1'
   spec.add_development_dependency 'minitest', '= 5.27.0'
   spec.add_development_dependency 'minitest-reporters'


### PR DESCRIPTION
The core gem's Machine::Utilities#run_scope is identical and the only implementation ever invoked. Requires state_machines-activemodel >= 0.200.0.

Release-As: 0.200.0