### PR TITLE
fix: re-register integer attribute type when a machine is cloned for a subclass

### DIFF
--- a/lib/state_machines/integrations/active_record.rb
+++ b/lib/state_machines/integrations/active_record.rb
@@ -387,6 +387,22 @@ module StateMachines
           register_integer_type if register_integer_type?
         end
 
+        # Hook called when a machine is assigned to a class, including when an
+        # inherited machine is cloned for an STI subclass. The cloned machine
+        # carries the parent's @integer_type_registered flag while the subclass
+        # still inherits the parent's attribute type, which references the
+        # parent machine's state collection. Re-register so the subclass type
+        # sees this machine's (cloned) states, picking up subclass-added states
+        # as they are defined.
+        #
+        # @param klass [Class] the new owner class
+        # @return [Class] the assigned owner class
+        def owner_class=(klass)
+          super.tap do
+            register_integer_type if integer_type_registered?
+          end
+        end
+
         # Check if enum integration should be enabled for this machine
         def detect_enum_integration
           return nil unless owner_class.defined_enums.key?(attribute.to_s)
@@ -521,7 +537,13 @@ module StateMachines
         def register_integer_type
           @raw_integer_column_default = owner_class.column_defaults[attribute.to_s]
           @integer_type_registered = true
-          raw_type = owner_class.type_for_attribute(attribute.to_s)
+
+          # When re-registering (e.g. for an STI subclass that inherited the
+          # parent's custom type), unwrap it to keep the column's original type
+          # as the passthrough delegate.
+          current_type = owner_class.type_for_attribute(attribute.to_s)
+          raw_type = current_type.is_a?(StateMachines::Type::Integer) ? current_type.raw_type : current_type
+
           owner_class.attribute(attribute.to_s, StateMachines::Type::Integer.new(states, raw_type: raw_type))
         end
 

--- a/lib/state_machines/integrations/active_record/type/integer.rb
+++ b/lib/state_machines/integrations/active_record/type/integer.rb
@@ -16,6 +16,12 @@ module StateMachines
     # type, preserving the classic raw-integer behavior
     # (e.g. record.status # => 1, record.status_name # => :approved).
     class Integer < ::ActiveRecord::Type::Value
+      # The column's original attribute type, exposed so re-registration
+      # (e.g. for STI subclasses) can reuse it instead of wrapping this type.
+      #
+      # @return [ActiveModel::Type::Value]
+      attr_reader :raw_type
+
       # @param states [StateMachines::StateCollection] live collection of the
       #   machine's states; held by reference because states are defined after
       #   the type is registered

--- a/test/machine_with_integer_column_sti_subclass_test.rb
+++ b/test/machine_with_integer_column_sti_subclass_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Subclasses that extend an inherited machine get a cloned state collection,
+# but they inherit the parent's custom integer attribute type, which references
+# the parent machine's states. The integration must re-register the type on the
+# subclass so subclass-added states serialize to their own integers instead of
+# silently coercing to 0.
+class MachineWithIntegerColumnStiSubclassTest < BaseTestCase
+  def setup
+    @base = new_model do
+      connection.add_column table_name, :status, :integer, default: 0
+    end
+
+    @base_machine = StateMachines::Machine.new(@base, :status, initial: :pending) do
+      state :pending
+      state :shipped
+
+      event :ship do
+        transition pending: :shipped
+      end
+    end
+
+    @subclass = Class.new(@base)
+    @subclass_machine = @subclass.state_machine(:status) do
+      state :returned
+
+      event :return_order do
+        transition shipped: :returned
+      end
+    end
+
+    @record = @subclass.new
+    @record.ship!
+  end
+
+  def test_subclass_machine_is_a_copy
+    refute_same @base_machine, @subclass_machine
+  end
+
+  def test_subclass_added_state_persists_its_own_integer
+    @record.return_order!
+    raw = @subclass.connection.select_value("SELECT status FROM #{@subclass.quoted_table_name} WHERE id = #{@record.id}")
+
+    assert_equal 2, raw.to_i
+  end
+
+  def test_subclass_added_state_reads_back
+    @record.return_order!
+    reloaded = @subclass.find(@record.id)
+
+    assert_equal 'returned', reloaded.status
+    assert_equal :returned, reloaded.status_name
+  end
+
+  def test_inherited_states_still_convert_on_subclass
+    assert_equal 'shipped', @record.status
+    assert @record.shipped?
+  end
+
+  def test_base_class_type_unaffected
+    base_record = @base.new
+    base_record.ship!
+    raw = @base.connection.select_value("SELECT status FROM #{@base.quoted_table_name} WHERE id = #{base_record.id}")
+
+    assert_equal 1, raw.to_i
+    assert_equal 'shipped', @base.find(base_record.id).status
+  end
+end


### PR DESCRIPTION
Subclasses extending an inherited machine got the parent's attribute type, which references the parent's state collection, so subclass-added states silently serialized to 0. 

Re-registering on owner_class= keeps the type bound to the cloned collection.